### PR TITLE
Run Travis tests against multiple JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,6 @@
 language: clojure
 script: lein test-all
+jdk:
+ - openjdk8
+ - openjdk11
+ - openjdk-ea


### PR DESCRIPTION
To flush out any issues with newer versions of the JDK.