### PR TITLE
Fix empty all-classpath-urls on Java 9+

### DIFF
--- a/src/dynapath/util.clj
+++ b/src/dynapath/util.clj
@@ -1,7 +1,8 @@
 (ns dynapath.util
   "Abstracts the getURLs and addURL functionality of URLClassLoader to a protocol."
   (:require [dynapath.dynamic-classpath :as dc]
-            dynapath.defaults)) ;; trigger the default implementations
+            dynapath.defaults) ;; trigger the default implementations
+  (:import [java.io File]))
 
 (defn addable-classpath?
   "Returns true if the given ClassLoader provides add-claspath-url."
@@ -21,11 +22,21 @@
   (if (readable-classpath? cl)
     (dc/classpath-urls cl)))
 
+(defn- system-classpath
+  "Starting with Java 9, the default class loader is no longer an
+  instance of URLClassLoader, so `classpath` returned an empty sequence.
+  See more in clojure/java.classpath"
+  []
+  (map #(-> (File. ^String %) .toURI .toURL)
+       (.split (System/getProperty "java.class.path")
+               (System/getProperty "path.separator"))))
+
 (defn all-classpath-urls
   "Walks up the parentage chain for a ClassLoader, concatenating any URLs it retrieves.
 If no ClassLoader is provided, RT/baseLoader is assumed."
   ([]
-     (all-classpath-urls (clojure.lang.RT/baseLoader)))
+   (or (seq (all-classpath-urls (clojure.lang.RT/baseLoader)))
+       (system-classpath)))
   ([cl]
      (->> (iterate #(.getParent ^ClassLoader %) cl)
           (take-while identity)

--- a/test/dynapath/util_test.clj
+++ b/test/dynapath/util_test.clj
@@ -37,8 +37,11 @@
 
   (deftest all-classpath-urls-should-use-the-baseLoader-when-called-with-a-zero-arity
     (add-classpath-url (clojure.lang.RT/baseLoader) (first urls))
-    (= (first urls) (last (all-classpath-urls))))
-  
+    (is (= (first urls) (last (all-classpath-urls)))))
+
+  (deftest all-classpath-urls-always-returns-something-when-called-with-a-zero-arity
+    (is (seq (all-classpath-urls))))
+
   (deftest add-classpath-url-should-work-for-an-addable-classpath
     (is (add-classpath-url *dynamic-cl* (last all-urls)))
     (is (= [(last all-urls)] (classpath-urls *dynamic-cl*))))


### PR DESCRIPTION
This doesn't cover modifications, but still, some libraries are depending on dynapath just to *read* all things without a special classloader (e.g. bultitude)

Also, after that `(not= (all-classpath-urls) (all-classpath-urls (clojure.lang.RT/baseLoader)))` on jdk >= 9, which were historically the same on previous jdk, but I think this can make sense and something it better than an empty list anyway.

Related to https://github.com/tobias/dynapath/issues/12